### PR TITLE
Using 2019-03-22 API version for IoT Hub ARM template.

### DIFF
--- a/deploy/templates/azuredeploy.infrastructure.json
+++ b/deploy/templates/azuredeploy.infrastructure.json
@@ -543,8 +543,7 @@
             },
             "properties": {
                 "location": "[resourceGroup().location]",
-                "ipFilterRules": [
-                ],
+                "ipFilterRules": [],
                 "eventHubEndpoints": {
                     "events": {
                         "retentionTimeInDays": 1,
@@ -553,14 +552,10 @@
                 },
                 "routing": {
                     "endpoints": {
-                        "serviceBusQueues": [
-                        ],
-                        "serviceBusTopics": [
-                        ],
-                        "eventHubs": [
-                        ],
-                        "storageContainers": [
-                        ]
+                        "serviceBusQueues": [],
+                        "serviceBusTopics": [],
+                        "eventHubs": [],
+                        "storageContainers": []
                     },
                     "routes": [
                         {

--- a/tools/templates/simulation_linux_iot.json
+++ b/tools/templates/simulation_linux_iot.json
@@ -76,7 +76,7 @@
     "variables": {
         "tenantId": "[subscription().tenantId]",
         "location": "[resourceGroup().location]",
-        "iotHubApiVersion": "2018-04-01",
+        "iotHubApiVersion": "2019-03-22",
         "iotHubResourceId": "[resourceId('Microsoft.Devices/Iothubs', parameters('iotHubName'))]",
         "iotHubKeyName": "iothubowner",
         "iotHubContainerName": "[parameters('iotHubName')]",
@@ -104,10 +104,6 @@
                     "events": {
                         "retentionTimeInDays": 1,
                         "partitionCount": "[parameters('iotHubPartitionCount')]"
-                    },
-                    "operationsMonitoringEvents": {
-                        "retentionTimeInDays": 1,
-                        "partitionCount": 4
                     }
                 },
                 "routing": {

--- a/tools/templates/simulation_windows_iot.json
+++ b/tools/templates/simulation_windows_iot.json
@@ -76,7 +76,7 @@
     "variables": {
         "tenantId": "[subscription().tenantId]",
         "location": "[resourceGroup().location]",
-        "iotHubApiVersion": "2018-04-01",
+        "iotHubApiVersion": "2019-03-22",
         "iotHubResourceId": "[resourceId('Microsoft.Devices/Iothubs', parameters('iotHubName'))]",
         "iotHubKeyName": "iothubowner",
         "iotHubContainerName": "[parameters('iotHubName')]",
@@ -104,10 +104,6 @@
                     "events": {
                         "retentionTimeInDays": 1,
                         "partitionCount": "[parameters('iotHubPartitionCount')]"
-                    },
-                    "operationsMonitoringEvents": {
-                        "retentionTimeInDays": 1,
-                        "partitionCount": 4
                     }
                 },
                 "routing": {


### PR DESCRIPTION
Removed "operationsMonitoringEvents" Event Hub endpoint since 2019-03-22 API version only expects "events" Event Hub endpoint.